### PR TITLE
[Feature] Always prompt the user before promoting a silver

### DIFF
--- a/gshogi/gshogi.py
+++ b/gshogi/gshogi.py
@@ -239,13 +239,17 @@ class Game:
         move = self.src + dst
         # check for promotion
         if self.promotion_zone(src, dst, self.stm):
-            promote = self.board.promote(piece, src_x, src_y, dst_x, dst_y, self.stm)                           
-            if (promote == 2): 
-                # must promote                    
-                move = move + "+" 
-            elif (promote == 1):                    
-                # promotion is optional             
-                if self.ask_before_promoting:                        
+            promote = self.board.promote(piece, src_x, src_y, dst_x, dst_y, self.stm)
+            if (promote == 2):
+                # must promote
+                move = move + "+"
+            elif (promote == 1):
+                # promotion is optional
+                #
+                # But always prompt before promoting a silver since it
+                # can be valuable to have an unpromoted silver on the
+                # opposite side of the board.
+                if self.ask_before_promoting or piece == " s" or piece == " S":
                     response = self.gui.promote_popup()
                     if (response == gtk.RESPONSE_CANCEL):
                         return None


### PR DESCRIPTION
By default the program will automatically promote pieces once they
reach the other side of the board.  That is almost always desirable.
However, it can be strategically advantageous to leave a silver
general unpromoted.  We can prevent the automatic promotion by
toggling 'Ask Before Promotion' in the Options menu, but that has the
tedious side-effect of requiring us to answer the prompt for every
possible promotion.

This patch implements a convenient compromise between the default
behavior and prompting for promotion: moving a silver general to the
opposite side of the board will always trigger the prompt, even if
'Ask Before Promotion' is disabled.  This lets us have automatic
promotion for all of the other pieces while also letting us control
whether or not we want to promote a silver.

Signed-off-by: Eric James Michael Ritz ejmr@plutono.com
