### PR TITLE
[Feature] Support three pawn handicap games

### DIFF
--- a/gshogi/gshogi.py
+++ b/gshogi/gshogi.py
@@ -757,6 +757,9 @@ class Game:
             elif menu_name == "TenPieceHandicap":
                 sfen = "4k4/9/ppppppppp/9/9/9/" \
                        "PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+            elif menu_name == "ThreePawnHandicap":
+                sfen = "4k4/9/9/9/9/9/" \
+                       "PPPPPPPPP/1B5R1/LNSGKGSNL w 3p - 1"
             else:
                 gv.gui.info_box("Error. Invalid menu name:" + menu_name)
                 return

--- a/gshogi/gui.py
+++ b/gshogi/gui.py
@@ -136,6 +136,8 @@ class Gui:
              _("Eight Piece Handicap"), gv.gshogi.new_game_cb),
             ("TenPieceHandicap", None, _("_10 Pieces"), None,
              _("Ten Piece Handicap"), gv.gshogi.new_game_cb),
+            ("ThreePawnHandicap", None, _("_3 Pawns"), None,
+            _("Three Pawn Handicap"), gv.gshogi.new_game_cb),
             ("NewHandicapGame", None, _("_New Handicap Game")),
             #
             ("Quit", Gtk.STOCK_QUIT, _("_Quit"), None,
@@ -216,6 +218,7 @@ class Gui:
                     <menuitem action="SixPieceHandicap"/>
                     <menuitem action="EightPieceHandicap"/>
                     <menuitem action="TenPieceHandicap"/>
+                    <menuitem action="ThreePawnHandicap"/>
                 </menu>
                 <separator/>
                 <menuitem action="LoadGame"/>

--- a/gshogi/psn.py
+++ b/gshogi/psn.py
@@ -185,6 +185,9 @@ class Psn:
                 elif handicap == "ten piece":
                     sfen = "4k4/9/ppppppppp/9/9/9/PPPPPPPPP/" \
                            "B5R1/LNSGKGSNL w - 1"
+                elif handicap == "three pawn":
+                    sfen = "4k4/9/9/9/9/9/" \
+                           "PPPPPPPPP/1B5R1/LNSGKGSNL w - 3p 1"
 
                 if sfen != "":
                     startpos, stm = self.process_sfen(sfen)

--- a/locale/gshogi.pot
+++ b/locale/gshogi.pot
@@ -417,6 +417,14 @@ msgstr ""
 msgid "Ten Piece Handicap"
 msgstr ""
 
+#: gshogi/guy.py:139
+msgid "_3 Pawns"
+msgstr ""
+
+#: gshogi/guy.py:140
+msgid "Three Pawn Handicap"
+msgstr ""
+
 #: gshogi/gui.py:137
 msgid "_New Handicap Game"
 msgstr ""


### PR DESCRIPTION
The most severe handicap is for White to have nothing but his King,
i.e. the "naked king" handicap.  An unofficial step up from that is
for White to still have nothing but his King on board; but he begins
the game with three pawns in hand.  This lets White start by playing,
for example, a pawn drop to trick Black into losing his Bishop.

This patch implements the three pawn handicap style.  The video below
explains the nature of the handicap in more detail, three minutes in.

The actual implementation does nothing but add an SFEN notation for
the initial state of the game along with a new menu option.  The AI
tends to automatically go for that trick pawn drop, and so inherently
plays the handicap "correctly".

Signed-off-by: Eric James Michael Ritz <ericjmritz@yandex.com>

See-Also: https://www.youtube.com/watch?v=0w8_69flGjY&index=25&list=PL587865CAE59EB84A