### PR TITLE
Minor bugfixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 Minor modifications for 0.5.1
 ----------------------------------
+2017-05-28 Bernd Wille
+    * Bugfix initialisation of header fields
+    * Bugfix reads now games with repetition (sennichite)
+
 2017-04-06 Bernd Wille
     * Bugfix: Header from Multigame-Files (*.psn) are read now correctly
     * Move and Comment-Lists (-mh Options) look a little bit nicer now

--- a/gshogi/load_save.py
+++ b/gshogi/load_save.py
@@ -130,6 +130,11 @@ class Load_Save:
 
     def get_header_from_file(self, fname):
         # sente,gote,event, date
+        # initialize fields to be displayed
+        gv.gamedate=""
+        gv.gote=""
+        gv.sente=""
+        gv.event=""
         try:
                 f = open(fname)
         except:

--- a/gshogi/psn.py
+++ b/gshogi/psn.py
@@ -16,6 +16,9 @@
 #   You should have received a copy of the GNU General Public License
 #   along with gshogi.  If not, see <http://www.gnu.org/licenses/>.
 #
+#Remark on games read from files: number of move in SFEN-String is ignored since it would be too complicated to
+#correct all routines depending on number of records in movelist or length of movelist.
+#Repetition is read in when loaded from file bw 5'17
 
 from . import gv
 if gv.installed:
@@ -136,8 +139,14 @@ class Psn:
             stm = WHITE
         else:
             stm = BLACK
+        # only for malformed files:
+        if len(sfenlst)!=3:
+            if len(sfenlst) ==2:
+                move = int(sfenlst[2])
+        elif sfenlst[3]!="":
+            move = int(sfenlst[3])
         engine.setplayer(stm)
-        return startpos, stm
+        return startpos, stm, move
 
     # called from utils.py as well as this module
     def load_game_psn_from_str(self, gamestr):
@@ -149,7 +158,7 @@ class Psn:
         startpos = "startpos"
         engine.command("new")
         stm = BLACK
-
+        moveread = 0
         movecnt = 0
 
         self.gamestr = gamestr
@@ -195,7 +204,7 @@ class Psn:
                 return 1
             if prop == "SFEN":
                 # set board position, side to move
-                startpos, stm = self.process_sfen(value)
+                startpos, stm, moveread = self.process_sfen(value)  #moveread from position
             elif prop == "Handicap":
 
                 handicap = value.strip('"')
@@ -234,7 +243,7 @@ class Psn:
                            "PPPPPPPPP/1B5R1/LNSGKGSNL w - 3p 1"
 
                 if sfen != "":
-                    startpos, stm = self.process_sfen(sfen)
+                    startpos, stm, moveread= self.process_sfen(sfen)
 
             hdr, newptr = self.get_header(ptr)
 
@@ -314,9 +323,9 @@ class Psn:
                         "Error loading file, illegal move (possible "
                         "sennichite (repetition)):" + move + " move number:" +
                         str(movecnt + 1))
-                    gv.gshogi.new_game("NewGame")
-                    gv.gui.set_status_bar_msg("Error loading game")
-                    return 1
+                    #gv.gshogi.new_game("NewGame")
+                    #gv.gui.set_status_bar_msg("Error loading game")
+                    #return 1
                 movecnt += 1
                 movelist.append(move)
                 lastmove = move


### PR DESCRIPTION
Hi John,
I added a bugfix - fields read from a file and displayed in the header are now initialized correctly.
I made the program ignore an error message created when reading draw games by repetition. I also thought about making the program read and display the move number from SFEN-strings but deceided the consequences for maintaining the movelist are too complicated for me at the time being.

I will add some small programs to my github site which read in kifu and USL-files and translate them to psn as read by gshogi. Perhaps you may find them useful.